### PR TITLE
Initial queue for register route

### DIFF
--- a/packages/contracts/contracts/AddressAttester.sol
+++ b/packages/contracts/contracts/AddressAttester.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 import {Unirep} from "@unirep/contracts/Unirep.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 
 // Uncomment this line to use console.log
 // import "hardhat/console.sol";
 
-contract AddressAttester is Ownable {
+contract AddressAttester {
 
     // root stored onchain
     bytes32 public root;
@@ -24,11 +23,13 @@ contract AddressAttester is Ownable {
         unirep.attesterSignUp(_epochLength);
     }
 
-    
+    function setRoot(bytes32 newRoot) public {
+        root = newRoot;
+    }
+
     function getRoot() public view returns (bytes32) {
       return root;
     }
-
 
     // sign up users in this app
     function userSignUp(

--- a/packages/contracts/contracts/AddressAttester.sol
+++ b/packages/contracts/contracts/AddressAttester.sol
@@ -9,40 +9,24 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 contract AddressAttester is Ownable {
 
     // root stored onchain
-    uint SMTRoot;
+    bytes32 public root;
 
     Unirep public unirep;
 
-    mapping (address => bool) public registeredAddresses;
-
-    constructor(Unirep _unirep, uint256 _epochLength) {
+    constructor(Unirep _unirep, uint256 _epochLength, bytes32 _root) {
         // set unirep address
         unirep = _unirep;
+
+        // set SMT root
+        root = _root;
 
         // sign up as an attester
         unirep.attesterSignUp(_epochLength);
     }
 
     
-    function getRoot() public view returns (uint) {
-      return SMTRoot;
-    }
-
-    // strictly reserved for owner of contract
-    function setRoot(uint _SMTRoot) public onlyOwner (){
-      SMTRoot = _SMTRoot;
-    } 
-
-    // insert into the tree -- index is the Address and value is 1
-    function register(address addr) public {
-        // check if Address hasn't been registered before and only the address owner can register it
-        require(!registeredAddresses[addr]); 
-        require(msg.sender == addr);
-        registeredAddresses[addr] = true;
-    }
-
-    function verify(address addr) public view returns (bool) {
-        return registeredAddresses[addr];
+    function getRoot() public view returns (bytes32) {
+      return root;
     }
 
 
@@ -52,23 +36,6 @@ contract AddressAttester is Ownable {
         uint256[8] memory proof
     ) public {
         unirep.userSignUp(publicSignals, proof);
-    }
-
-    // submit attestations (fields may change with https://github.com/Unirep/Unirep/issues/285)
-    function submitAttestation(
-        uint256 targetEpoch,
-        uint256 epochKey,
-        uint256 posRep,
-        uint256 negRep,
-        uint256 graffiti
-    ) public {
-        unirep.submitAttestation(
-            targetEpoch,
-            epochKey,
-            posRep,
-            negRep,
-            graffiti
-        );
     }
 
     // todo: Verify proofs when circuits are built

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,5 +24,7 @@
     "@unirep/contracts": "2.0.0-alpha-2",
     "hardhat": "^2.12.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@unirep/utils": "^2.0.0-alpha-4"
+  }
 }

--- a/packages/contracts/scripts/deploy.mjs
+++ b/packages/contracts/scripts/deploy.mjs
@@ -1,40 +1,44 @@
-import fs from 'fs'
-import path from 'path'
-import url from 'url'
-import { createRequire } from 'module'
-import { deployUnirep } from '@unirep/contracts/deploy/index.js'
-import hardhat from 'hardhat'
-const { ethers } = hardhat
+import fs from "fs";
+import path from "path";
+import url from "url";
+import { createRequire } from "module";
+import { deployUnirep } from "@unirep/contracts/deploy/index.js";
+import hardhat from "hardhat";
+const { ethers } = hardhat;
 
-const require = createRequire(import.meta.url)
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
-const UnirepApp = require("../abi/UnirepApp.json")
+const UnirepApp = require("../abi/AddressAttester.json");
 
-const [signer] = await ethers.getSigners()
-const unirep = await deployUnirep(signer)
-const epochLength = 100
+const [signer] = await ethers.getSigners();
+const unirep = await deployUnirep(signer);
+const epochLength = 100;
 
-const App = await ethers.getContractFactory('UnirepApp');
+const App = await ethers.getContractFactory("UnirepApp");
 const app = await App.deploy(unirep.address, epochLength);
 
 await app.deployed();
 
-console.log(`Unirep app with epoch length ${epochLength} deployed to ${app.address}`);
+console.log(
+  `Unirep app with epoch length ${epochLength} deployed to ${app.address}`
+);
 
-const config =
-`module.exports = {
+const config = `module.exports = {
   UNIREP_ADDRESS: '${unirep.address}',
   APP_ADDRESS: '${app.address}',
-  ETH_PROVIDER_URL: '${hardhat.network.config.url ?? ''}',
-  ${Array.isArray(hardhat.network.config.accounts) ? `PRIVATE_KEY: '${hardhat.network.config.accounts[0]}',` :
-`/**
+  ETH_PROVIDER_URL: '${hardhat.network.config.url ?? ""}',
+  ${
+    Array.isArray(hardhat.network.config.accounts)
+      ? `PRIVATE_KEY: '${hardhat.network.config.accounts[0]}',`
+      : `/**
     This contract was deployed using a mnemonic. The PRIVATE_KEY variable needs to be set manually
-  **/`}
+  **/`
+  }
 }
-`
+`;
 
-const configPath = path.join(__dirname, '../../../config.js')
-await fs.promises.writeFile(configPath, config)
+const configPath = path.join(__dirname, "../../../config.js");
+await fs.promises.writeFile(configPath, config);
 
-console.log(`Config written to ${configPath}`)
+console.log(`Config written to ${configPath}`);

--- a/packages/relay/src/routes/smt.mjs
+++ b/packages/relay/src/routes/smt.mjs
@@ -12,28 +12,45 @@ const depth = 26;
 const zeroHash = 0;
 
 const tree = new SparseMerkleTree(depth, zeroHash, arity);
+const queue = [];
+let isVerifying = false;
 
 export default ({ app, db, synchronizer }) => {
   app.post("/api/register", async (req, res) => {
     try {
-      // todo: make zkproof setting the leaf at their address index to 1
       // todo: grab address from frontend or somewhere
-      // const { ethAddress } = req.body;
-      // add eth address to the SMT
-      tree.update(ethAddress, 1);
-      // send root to smart contract
-      let root = tree.root;
-      // post root on chain
-      const appContract = new ethers.Contract(
-        ATTESTERADD_ADDRESS,
-        UnirepApp.abi
-      );
-      const calldata = appContract.interface.encodeFunctionData(
-        "setRoot",
-        root
-      );
+      const { ethAddress } = req.body;
+      queue.push(ethAddress);
+      verifyAddress();
     } catch (error) {
       res.status(500).json({ error });
     }
   });
+
+  async function verifyAddress() {
+    if (isVerifying || queue.length === 0) {
+      return;
+    }
+
+    isVerifying = true;
+    const ethAddress = queue.shift();
+    // todo: add zk proof here to check if address is in SMT
+    // todo: ====
+    // add eth address to the SMT
+    tree.update(ethAddress, 1);
+    // send root to smart contract and post root on chain
+    let root = tree.root;
+    const appContract = new ethers.Contract(ATTESTERADD_ADDRESS, UnirepApp.abi);
+    const calldata = appContract.interface.encodeFunctionData("setRoot", root);
+    // send the transaction to the blockchain
+    const hash = await TransactionManager.queueTransaction(
+      appContract.address,
+      calldata
+    );
+
+    res.json({ hash });
+
+    isVerifying = false;
+    verifyAddress();
+  }
 };


### PR DESCRIPTION
This PR adds an initial queue for signups. 

This is necessary because a race condition can occur if a zkproof is still verifying an address.

Addresses #11 